### PR TITLE
release: v0.2.0

### DIFF
--- a/conventions/specification/configuration.md
+++ b/conventions/specification/configuration.md
@@ -1,0 +1,23 @@
+# Configuration
+
+Environment variables can be used to set the values of the paramter. For example, to set `conn.DATABASE_URL`, the environment variable `CONN_DATABASE_URL` will be read as the default.
+
+## Connection Configuration
+
+- CONN_CACHE_URL - The connection url to the cache middleware
+  - alias: CACHE_URL
+- CONN_DATABASE_URL - The connection url to the database server
+  - alias: DATABASE_URL
+- CONN_BUS_URL - The connection url to the service bus
+  - alias: BUS_URL
+
+## Bus Configuration
+
+- EVENTEXCHANGENAME - the exchange name to use for event. default: 'amqp.fanout'
+- EXCHANGENAME - the exchange name to use for normal bus communication. default: ''
+- PREFIX - the prefix to use for routing keys. default: ''
+
+## Server Configuration
+
+- PORT - the port for the web interface to listen onto. default: 3000
+- INSTANCE_ID - the instance id to use to uniquely identify the server. default: hostname

--- a/conventions/specification/event.md
+++ b/conventions/specification/event.md
@@ -1,7 +1,41 @@
 # Event
 
+Events are emitted via the bus on the `eventExchangeName`. Not all services need to process every event. Servers that are type 'EventEmitters' will only emit events and not respond to messages.
+
+## Process Diagram
+
+```mermaid
+sequenceDiagram
+  actor Client1
+  actor Client2
+  actor Client3
+  participant Topic1
+  participant Topic2
+  box Middleware
+    participant Bus
+  end
+  participant Service
+
+  Client1--)Topic1: Subscribe
+  Client2--)Topic2: Subscribe
+  Client3--)Topic2: Subscribe
+
+  Service-)Bus: Emits event to EventExchange
+  par
+    Bus-)Topic1: Receives event
+    Topic1-)Client1: Deliver Event
+  and
+    Bus-)Topic2: Receives event
+    Note over Client2,Client3: One Client per Topic
+    Topic2-)Client3: Deliver Event
+  end
+```
+
+## Structure
+
 ```javascript
 {
+  "type": "event"
   "route": "string"         // routing key to the event Emitter
   "instanceId": "string"    // instance id of event Emitter
   "event":  "string"        // event name

--- a/conventions/specification/input.md
+++ b/conventions/specification/input.md
@@ -1,48 +1,69 @@
 # Input Payload Structure
 
+Input messages are communicated over the bus in the exchange `exchangeName`. Arguments to couple with the inputs are stored in the cache. This is to ensure that large messages are not sent over the bus because smaller messages travel faster. Ids can be generated to be utilized for caching. If the output to the `input.id` exists, then there is no need to send the message in the bus. This establishes a form of caching and invalidation. Specifying an instance id is able to narrow the processing to a specific service out of a collection matching to a routing key.
+
+## Process Diagram
+
+The `IdGenerator` generates the id based on the input and current state. Thus, the id is a function of state and input and performs passive cache invalidation.
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor Client1
+  actor Client2
+  box Middleware
+    participant Bus
+    participant Cache
+  end
+  participant IdGenerator
+  participant Service
+
+  activate Client1
+  Client1->>IdGenerator: Generate ids for input and argument artifact.
+  activate IdGenerator
+  IdGenerator-)Client1: Send generated ids
+  deactivate IdGenerator
+  Client1->>Cache: Check and validate Response Artifact not in Cache
+  Client1->>Cache: Store argument as an artifact
+  Client1-)Bus: Send input with ids and routing key
+  deactivate Client1
+
+  par Service Processing
+    Bus-)Service: Recieves input message
+    activate Service
+    Service->>Cache: Retrieves input arguments
+  and Concurrent Client Request
+    activate Client2
+    Client2->>IdGenerator: Generate ids for input and argument artifact.
+    activate IdGenerator
+    IdGenerator-)Client2: Send generated ids
+    deactivate IdGenerator
+    Client2->>Cache: Check and find Response Artifact in Cache
+    Client2-xCache: Process ends due to input caching
+    deactivate Client2
+  end
+  deactivate Service
+```
+
+## Input Structure
+
 ```javascript
 {
+  "type": "input"
   "id": "string"
   "route": "string"
-  "argumentId": "string"  // should be prefixed with arg_
-
+  "argumentId": "string"
   "instanceId"?: "string"
-  "conn"?: <CONN>
-  "log"?: <LOG>
-  "busConf"?: <BUSCONF>
-}
-
-CONN = PARTIAL<{
-  "CACHE_URL": "string"
-  "DATABASE_URL": "string"
-  "BUS_URL": "string"
-}>
-
-LOG = PARTIAL<{
-  "type": "http|bus|database"  // default database
-  "metrics": [
-    "serviceName",
-    "instanceId",
-    "inputPayload",
-    "duration",
-    "statusCode",
-    "isError"
-  ]
-  "database": PARTIAL<{
-    "tableName": "logging",
-    "columnMap": PARTIAL<{
-      [metricName]: "database columnName"
-    }>
-  }>
-}>
-
-BUSCONF = PARTIAL<{
-  eventExchangeName: "string"   // default: amq.fanout
-  exchangeName: "string"        // default: direct
-  routePrefix: "string"              // default: ""
 }>
 ```
 
-## Startup Arguments
+## Argument Artifact
 
-The program should accept all optional arguments as a JSON encoded string as the first argument.
+The `argumentId` should reference a key in the cache storage layer with a value following the following structure
+
+```
+{
+  "method": "string",
+  "inputs": "any"
+}
+```

--- a/conventions/specification/interface.md
+++ b/conventions/specification/interface.md
@@ -1,5 +1,7 @@
 # Interfaces
 
+The interface allows all services to act as an API layer because it can route to the appropriate location utilizing the bus layer.
+
 ## HTTP Interface
 
 The following routes are reserved and should be implemented to respond to the following requests,
@@ -7,8 +9,32 @@ The following routes are reserved and should be implemented to respond to the fo
 ```
 GET  /health      // respond 200 if okay, 500 if not
 GET  /ready       // respond 200 if ready, 500 if not
-POST /:prefix     // send a message with route prefix
-POST /id/:id      // set an id parameter in cache
+POST /            // send a message on the bus
 GET  /id/:id      // get value of id in cache.
                      a null value means it does not exist.
 ```
+
+Where `POST /` takes the same format as [input](./input.md), however `argumentId` will be an object and `id` will not be required. Instead, `argument` will be required and will take the format as the argument artifact.
+
+## Class Diagram
+
+```mermaid
+classDiagram
+
+  HTTPInterface..>Bus
+  HTTPInterface..>Cache
+
+  class HTTPInterface{
+    -int port
+    -string[] resolverFolders
+    -string route
+    -string instanceId
+    -Bus bus
+    -Cache cache
+  }
+
+  class Bus
+  class Cache
+```
+
+The interface will not only handle the web requests, it will spin up the bus and start listening for changes.

--- a/conventions/specification/naming_conventions.md
+++ b/conventions/specification/naming_conventions.md
@@ -1,8 +1,11 @@
 # Naming Conventions
 
+TODO: update with new names
+
 ```
 repository name: svc-[dns-compliant-name]
-artifact name: servc/svc-[dns-compliant-name]
+npm artifact name: servc-svc-[dns-compliant-name]
+container artifact name: servcorg/svc-[dns-compliant-name]
 topic/route: svc-[dns-compliant-name]
 event route:
   svc.event.[dns-compliant-instance].[verb]
@@ -13,7 +16,8 @@ example:
 
 ```
 repository name: svc-deluge
-artifact name: servc/svc-deluge
+npm artifact name: servc-svc-deluge
+container artifact name: servcorg/svc-deluge
 topic/route: svc-deluge
 event route:
   svc.event.deluge.completed-task

--- a/conventions/specification/response.md
+++ b/conventions/specification/response.md
@@ -1,16 +1,97 @@
 # Response Structure
 
+The response structure is specifically nonblocking in order to ensure maximum concurrency and throughput. The flow of data should always be one-direction with no blocking or polling in the service layers. All polling should be managed on the client side and the service should have no management of state in relationship to the input flow.
+
+## Process Flow Diagram
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor Client
+  box Middleware
+    participant Bus
+    participant Cache
+  end
+  participant Service
+
+  Bus-)Service: Recieves input message
+  activate Service
+
+  par Client Polling Loop
+    Client--)Cache: Polls cache for response artifact updates
+  and Service Processing
+    Service->>Cache: Retrieves input arguments
+    Service-)Bus: Emit events during processing
+    Service-)Cache: Stores updates during processing
+    Service-)Cache: Stores response artifact
+    deactivate Service
+  end
+
+  Client->>Cache: Retrieves final response artifact
+```
+
+## Response Structure
+
 ```javascript
 {
   "id": "string",
   "progress": "float",
   "statusCode": "int",
-  "responseBody": "string|json obj"
+  "responseBody": "string|json obj",
+  "isError": "boolean"
 }
 ```
+
+Where progress is always greatner than or equal to zero and less than or equal to 1.
 
 ## Status Codes
 
 - 200: Okay
 - 400: Bad Request. Invalid input
 - 500: Server error.
+
+The current state of processing can be determined based on the response structure and the status code.
+
+**Not Started or Not Sent**
+
+```javascript
+{
+  progress: 0;
+  isError: false;
+  statusCode: 200;
+  responseBody: string;
+}
+```
+
+**In Progress**
+
+```javascript
+{
+  progress: >0, <1;
+  isError: false;
+  statusCode: 200;
+  responseBody: string;
+}
+```
+
+**Finished**
+
+```javascript
+{
+  progress: 1;
+  isError: false;
+  statusCode: 200;
+  responseBody: string | object;
+}
+```
+
+**Error**
+
+```javascript
+{
+  progress: 1,
+  isError: true,
+  statusCode: >= 400
+  responseBody: string
+}
+```

--- a/frontend/specification/client.md
+++ b/frontend/specification/client.md
@@ -1,0 +1,60 @@
+# Client
+
+The client interacts with the [interface](../../conventions/specification/interface.md) of all services. The services can route the requests and thus any service can be used as a gateway to the full collection of microservices.
+
+Each request is considered a job and includes a polling block that delivers dynamic progress updates. Jobs can be grouped to form an aggregate job that will deliver a single response object.
+
+## Process Flow
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor FrontEnd
+  participant Service
+
+  activate FrontEnd
+  FrontEnd->>Service: Sends Job to Service, gets jobId
+  activate Service
+
+  par Polling Block
+    FrontEnd-)Service: Polls /id/:jobid to get updates/answer
+  and Service Processing
+    Service-)Service: Processes the job
+    deactivate Service
+  end
+
+  FrontEnd-)Service: Retrieves final output from /id/:jobid
+
+  deactivate FrontEnd
+```
+
+## Bulk Job Structure
+
+The bulk job input will be in the following format,
+
+```javascript
+{
+  [key: string]: JOB
+}
+```
+
+where key cannot be any of the keys in the [response artifact](../../conventions/specification/response.md). the key can only contain lowercase a-z characters.
+
+The bulk response will be in the same format as the response artifact except the response body will be following format
+
+```javascript
+{
+  [key: string]: JOB["responseBody"]
+}
+```
+
+## Bulk Job Processing
+
+All bulk job handling is frontend/client side. The service layer has no opionion or notion of bulk jobs.
+
+1. Send list of job requests to service and get job ids.
+2. Create an aggregate id using the following convention, `{key1}:{jobid1}_{key2}:{jobid2}`. Thus, the aggregate id retains the list of jobs that constitute the bulk job and the associated key to produce the response artifact.
+3. Perform aggregation of other fields using following rules:
+   1. Progress: average of all progress
+   2. isError: use bool_or approach
+   3. statusCode: highest number is the resulting statusCode

--- a/services/README.md
+++ b/services/README.md
@@ -1,29 +1,9 @@
 # Services Specification
 
-## Process Diagram
+## TOC
 
-```mermaid
-sequenceDiagram
-  autonumber
-  actor Client
-  box Middleware
-  participant Cache
-  participant Bus
-  end
-  participant Service
-
-  Note over Client,Bus: Message is sent not sent if the key svc_<id> exists in cache and is completed as success
-  Client->>Cache: Stores input object at key arg_<id2>
-  Client-)Bus: Sends message to service route with svc_<id>
-  par Client Polling Loop
-    Client-->Cache: Polls for response at key svc_<id>
-  and Service Processing
-    Bus-)Service: Recieves input message
-    activate Service
-    Service->>Cache: Retrieves input object at key arg_<id2>
-    Service-)Bus: Emits events during processing
-    Service-)Cache: Stores response at key svc_<id>
-  end
-  deactivate Service
-  Client->>Cache: Retrieves message at key svc_<id>
-```
+1. [Service Types](./specification/service_types.md)
+2. [Bus](./specification/bus.md)
+3. [Cache](./specification/cache.md)
+4. [Component](./specification/component.md)
+5. [Resolvers](./specification/resolvers.md)

--- a/services/specification/bus.md
+++ b/services/specification/bus.md
@@ -1,0 +1,29 @@
+# Bus Component
+
+The goal of the bus is simply to send messages and subscribe to topics.
+
+```mermaid
+classDiagram
+  ServiceComponent <|-- Bus
+
+  class Bus {
+    -constructor(connectionUrl: string, configuration: BusConfig)
+    +publishMessage(route, message, emitFunction): Promise~boolean~
+    +subscribeToRoute(route, inputProcessor, emitFunction, onConsuming): void
+  }
+```
+
+## Methods and Attributes
+
+### publishMessage(route, message, emitFunction)
+
+- **route** - the routing key to send. This will be prefixed
+- **message** - the message to send. if the type is event, it will publish to the event exchange. Otherwise, it will publish to the default exchange.
+- **emitFunction** - Callback function that is triggered when the message is emitted. The first argument is the message, the second argument is the route. Subsequent arguments are implementation specific.
+
+### subscribeToRoute(route, inputProcessor, emitFunction, onConsuming)
+
+- **route** - the routing key to send. This will be prefixed
+- **inputProcessor** - the method used to process messages upon arrival. The first argument is the message. The second argument will be the route that is currently being subscribed on. The message will be either an input or event. Subsequent arguments are implementation specific. The response will be a promise that resolves to a StatusCode.
+- **emitFunction** - Callback function that is triggered when the message is emitted. The first argument is the message, the second argument is the route. Subsequent arguments are implementation specific.
+- **onConsuming** - Callback function that is triggered when server begins consuming. The first argument route. Subsequent arguments are implementation specific.

--- a/services/specification/cache.md
+++ b/services/specification/cache.md
@@ -1,0 +1,25 @@
+# Cache Component
+
+The goal of the cache is simply to get and set key value pairs.
+
+```mermaid
+classDiagram
+  ServiceComponent <|-- Cache
+
+  class Cache {
+    -constructor(connectionUrl: string)
+    -keyExists(id: string): Promise~boolean~
+    +setKey(id: string, value: Artifact): Promise~id~
+    +getKey(id: string): Promise~Artifact|null~
+  }
+```
+
+## Methods and Attributes
+
+### keyExists(id: string)
+
+returns true if the id exists in the cache
+
+### setKey(id: string, value: Artifact)
+
+will store any serializable object in the cache. Currenly should only accept a argument artifact or a response artifact.

--- a/services/specification/component.md
+++ b/services/specification/component.md
@@ -1,0 +1,33 @@
+# Service Component and Middlewares
+
+```mermaid
+classDiagram
+  ServiceComponent <|-- Bus
+  ServiceComponent <|-- Cache
+
+  class ServiceComponent {
+    #ServiceComponent[] children
+    #boolean _isReady
+    #boolean _isOpen
+    #ComponentType _type
+
+    +isReady(): boolean
+    +isOpen(): boolean
+    +getType(): ComponentType
+    +connect(): Promise~any~
+    +close(): Promise~boolean~
+    +getChild(filter: ComponentType): ComponentType | null
+
+    #_connect(): Promise~any~*
+    #_close(): Promise~boolean~*
+  }
+
+  class Bus {
+
+  }
+
+  class Cache {
+
+  }
+
+```

--- a/services/specification/resolvers.md
+++ b/services/specification/resolvers.md
@@ -1,0 +1,28 @@
+# Resolvers
+
+All services handle events and inputs using resolvers. The only two types of input are an event or an input.
+
+## Input Resolvers
+
+Descrimination between input resolvers is identified by matching the method in the argument artifiact. The resolver that matches by name to the `method` parameter will be utilized to resolve the input and provide a response.
+
+| Arugment  | Type             | Description                                                                                                                                   |
+| --------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| id        | string           | the id of the input message                                                                                                                   |
+| bus       | Bus              | the bus class that recieved the message                                                                                                       |
+| cache     | Cache            | the cache class that contains the argument artifact. this should be used to store the response artifact.                                      |
+| inputs    | ArgumentArtifact | the argumentartifact with all the inputs retrieved from the cache                                                                             |
+| emitEvent | function         | A function that can be used to emit events into the bus. It accepts to arguments, eventName:string and the details as an serializable object. |
+
+## Event Resolvers
+
+Descrimination between event resolvers is identified by matching the `event` in the event payload. The resolver that matches by name to the `event` parameter will be utilized to resolve the event and do any required processing.
+
+| Arugment   | Type     | Description                                                                                                                                   |
+| ---------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| bus        | Bus      | the bus class that recieved the message                                                                                                       |
+| cache      | Cache    | the cache class that contains the argument artifact. this should be used to store the response artifact.                                      |
+| route      | string   | the route of the event emitter                                                                                                                |
+| instanceId | string   | the instanceId of the event emitter                                                                                                           |
+| details    | Object   | the details attributed to the event                                                                                                           |
+| emitEvent  | function | A function that can be used to emit events into the bus. It accepts to arguments, eventName:string and the details as an serializable object. |

--- a/services/specification/service_types.md
+++ b/services/specification/service_types.md
@@ -1,0 +1,16 @@
+# Service Types
+
+## Service (svc)
+
+The service will handle both input and event resolvers. Services can also emit events. Services are not expected to be always running and can scale to zero.
+
+## Event Emitter (evnt)
+
+The service will handle only event resolvers. Services are primarily used to emit events when attached to another external service/component. Always will be one-to-one relationship. Example: Deluge
+
+```mermaid
+erDiagram
+  EventEmitter ||--|| Deluge : events
+```
+
+A more detailed specification for event emitters will be outlined as its own section.


### PR DESCRIPTION
**Features**

- HTTP interface to take payload upfront and generate id and argumentId
- Server Options can be set using environment variables
- Input payload argument object requires a method and parameter for more structure
- Added "type" parameter to input and event for explicit declaration
- front end client specification defined for single and bulk jobs.
- defined resolvers for services

**Deprecations**
- Input payloads require method parameter.

**Breaking Changes**
- Removed set cache value from HTTP interface
- Server Options cannot be set via command line arguments and is not job specific.